### PR TITLE
Remove home access

### DIFF
--- a/org.gnome.Fractal.json
+++ b/org.gnome.Fractal.json
@@ -14,7 +14,6 @@
         "--device=dri",
         "--talk-name=org.freedesktop.secrets",
         "--talk-name=org.freedesktop.Notifications",
-        "--filesystem=home",
         "--metadata=X-DConf=migrate-path=/org/gnome/factal/"
     ],
     "build-options" : {


### PR DESCRIPTION
This is unnecessary considering that we use the file picker portal.