### PR TITLE
Update GNOME runtime to 41

### DIFF
--- a/org.gnome.Fractal.json
+++ b/org.gnome.Fractal.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.Fractal",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.38",
+    "runtime-version": "41",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": ["org.freedesktop.Sdk.Extension.rust-stable"],
     "command": "fractal",
@@ -22,7 +22,7 @@
     "add-extensions": {
         "org.freedesktop.Platform.ffmpeg-full": {
             "directory": "lib/ffmpeg",
-            "version": "20.08",
+            "version": "21.08",
             "add-ld-path": "."
         }
     },

--- a/org.gnome.Fractal.json
+++ b/org.gnome.Fractal.json
@@ -76,21 +76,20 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://download.gnome.org/sources/gspell/1.8/gspell-1.8.2.tar.xz",
-                    "sha256" : "bb9195c3a95bacf556d0203e9691f7489e0d3bc5ae1e5a440c89b2f2435d3ed6"
+                    "url" : "https://download.gnome.org/sources/gspell/1.8/gspell-1.8.4.tar.xz",
+                    "sha256" : "cf4d16a716e813449bd631405dc1001ea89537b8cdae2b8abfb3999212bd43b4"
                 }
             ]
         },
         {
             "name" : "gst-editing-services",
-            "config-opts" : [
-                "--disable-Werror"
-            ],
+            "buildsystem": "meson",
             "sources" : [
                 {
                     "type" : "git",
                     "url" : "https://gitlab.freedesktop.org/gstreamer/gst-editing-services.git",
-                    "tag" : "1.16.1"
+                    "tag" : "1.18.5",
+                    "commit" : "29dcc5c1a54f1fabf470bff15dd92b266c527909"
                 }
             ]
         },


### PR DESCRIPTION
`org.gnome.Platform 3.38` EOL now. We MUST upgrade to newer versions ASAP.