### PR TITLE
Port to Fractal 5 alpha 1

### DIFF
--- a/org.gnome.Fractal.json
+++ b/org.gnome.Fractal.json
@@ -1,9 +1,9 @@
 {
     "app-id": "org.gnome.Fractal",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "41",
+    "runtime-version": "43",
     "sdk": "org.gnome.Sdk",
-    "sdk-extensions": ["org.freedesktop.Sdk.Extension.rust-stable"],
+    "sdk-extensions": ["org.freedesktop.Sdk.Extension.rust-stable", "org.freedesktop.Sdk.Extension.llvm15"],
     "command": "fractal",
     "finish-args": [
         "--share=network",
@@ -22,7 +22,7 @@
     "add-extensions": {
         "org.freedesktop.Platform.ffmpeg-full": {
             "directory": "lib/ffmpeg",
-            "version": "21.08",
+            "version": "22.08",
             "add-ld-path": "."
         }
     },
@@ -38,26 +38,6 @@
         "/share/vala"
     ],
     "modules": [
-        {
-            "name" : "libhandy",
-            "buildsystem" : "meson",
-            "config-opts" : [
-                "-Dprofiling=false",
-                "-Dintrospection=enabled",
-                "-Dgtk_doc=false",
-                "-Dtests=false",
-                "-Dexamples=false",
-                "-Dvapi=false",
-                "-Dglade_catalog=disabled"
-            ],
-            "sources" : [
-                {
-                    "type" : "git",
-                    "url" : "https://source.puri.sm/Librem5/libhandy",
-                    "tag" : "v0.0.13"
-                }
-            ]
-        },
         {
             "name": "gspell",
             "config-opts" : [
@@ -76,8 +56,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://download.gnome.org/sources/gspell/1.8/gspell-1.8.4.tar.xz",
-                    "sha256" : "cf4d16a716e813449bd631405dc1001ea89537b8cdae2b8abfb3999212bd43b4"
+                    "url" : "https://download.gnome.org/sources/gspell/1.12/gspell-1.12.0.tar.xz",
+                    "sha256" : "40d2850f1bb6e8775246fa1e39438b36caafbdbada1d28a19fa1ca07e1ff82ad"
                 }
             ]
         },
@@ -88,22 +68,44 @@
                 {
                     "type" : "git",
                     "url" : "https://gitlab.freedesktop.org/gstreamer/gst-editing-services.git",
-                    "tag" : "1.18.5",
-                    "commit" : "29dcc5c1a54f1fabf470bff15dd92b266c527909"
+                    "tag" : "1.19.2",
+                    "commit" : "fc34303569d2e522f261498f4351e4fc6f610302"
+                }
+            ]
+        },
+        {
+            "name": "libshumate",
+            "buildsystem": "meson",
+            "config-opts": [
+                "-Dgir=false",
+                "-Dvapi=false",
+                "-Dgtk_doc=false",
+                "-Dlibsoup3=true"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://gitlab.gnome.org/GNOME/libshumate/",
+                    "tag": "1.0.3",
+                    "commit": "55d89e24de5086404b996a73e94cd56ee2e9541a"
                 }
             ]
         },
         {
             "name": "Fractal",
             "buildsystem": "meson",
+            "build-options":{
+                "prepend-path": "/usr/lib/sdk/llvm15/bin",
+                "prepend-ld-library-path": "/usr/lib/sdk/llvm15/lib"
+            },        
             "config-opts" : [
                 "-Dprofile=default"
              ],
             "sources": [
                 {
                     "type" : "archive",
-                    "url" : "https://gitlab.gnome.org/GNOME/fractal/uploads/d4168ac40fd681240964705e000dd353/fractal-4.4.0.tar.xz",
-                    "sha256": "65af7912f3d04bd6b2386b023415fef26afc48d256af205256f86396a1415825"
+                    "url" : "https://gitlab.gnome.org/GNOME/fractal/-/releases/5-alpha1/downloads/tarball/fractal-5-alpha1.tar.xz",
+                    "sha256": "643d5b260fbfc21ecc225bc2b76124b0bee54d80f591a40376b72bb3d95e7288"
                 }
             ]
         }


### PR DESCRIPTION
This port uses the latest alpha release for Fractal and updates all used dependencies and runtime versions.